### PR TITLE
[program]: Add the code to save a Proof-generated locally

### DIFF
--- a/circuits/circuit-for-distributor/.gitignore
+++ b/circuits/circuit-for-distributor/.gitignore
@@ -24,3 +24,6 @@ pgo-data.profdata
 ./program/Cargo.lock
 ./script/Cargo.lock
 **/Cargo.lock
+
+# Proof binaries
+proof-with-pis.bin

--- a/circuits/circuit-for-distributor/script/src/main.rs
+++ b/circuits/circuit-for-distributor/script/src/main.rs
@@ -100,6 +100,11 @@ fn main() {
     let mut proof = client.prove(&pk, &stdin).run().unwrap();
     println!("Successfully generated proof!");
 
+    // Save the proof locally. (Test a round trip of proof serialization and deserialization)
+    proof.save("proof-with-pis.bin").expect("saving proof failed");
+    let deserialized_proof = SP1ProofWithPublicValues::load("proof-with-pis.bin").expect("loading proof failed");
+    println!("Successfully save the proof!");
+
     // Verify the proof.
     client.verify(&proof, &vk).expect("failed to verify proof");
     println!("Successfully verified proof!");

--- a/circuits/circuit-for-manufacturer/.gitignore
+++ b/circuits/circuit-for-manufacturer/.gitignore
@@ -24,3 +24,6 @@ pgo-data.profdata
 ./program/Cargo.lock
 ./script/Cargo.lock
 **/Cargo.lock
+
+# Proof binaries
+proof-with-pis.bin

--- a/circuits/circuit-for-manufacturer/script/src/main.rs
+++ b/circuits/circuit-for-manufacturer/script/src/main.rs
@@ -93,6 +93,11 @@ fn main() {
     let mut proof = client.prove(&pk, &stdin).run().unwrap();
     println!("Successfully generated proof!");
 
+    // Save the proof locally. (Test a round trip of proof serialization and deserialization)
+    proof.save("proof-with-pis.bin").expect("saving proof failed");
+    let deserialized_proof = SP1ProofWithPublicValues::load("proof-with-pis.bin").expect("loading proof failed");
+    println!("Successfully save the proof!");
+
     // Verify the proof.
     client.verify(&proof, &vk).expect("failed to verify proof");
     println!("Successfully verified proof!");

--- a/circuits/circuit-for-retailer/.gitignore
+++ b/circuits/circuit-for-retailer/.gitignore
@@ -24,3 +24,6 @@ pgo-data.profdata
 ./program/Cargo.lock
 ./script/Cargo.lock
 **/Cargo.lock
+
+# Proof binaries
+proof-with-pis.bin

--- a/circuits/circuit-for-retailer/script/src/main.rs
+++ b/circuits/circuit-for-retailer/script/src/main.rs
@@ -85,6 +85,11 @@ fn main() {
     let mut proof = client.prove(&pk, &stdin).run().unwrap();
     println!("Successfully generated proof!");
 
+    // Save the proof locally. (Test a round trip of proof serialization and deserialization)
+    proof.save("proof-with-pis.bin").expect("saving proof failed");
+    let deserialized_proof = SP1ProofWithPublicValues::load("proof-with-pis.bin").expect("loading proof failed");
+    println!("Successfully save the proof!");
+
     // Verify the proof.
     client.verify(&proof, &vk).expect("failed to verify proof");
     println!("Successfully verified proof!");

--- a/circuits/circuit-for-supplier/.gitignore
+++ b/circuits/circuit-for-supplier/.gitignore
@@ -24,3 +24,6 @@ pgo-data.profdata
 ./program/Cargo.lock
 ./script/Cargo.lock
 **/Cargo.lock
+
+# Proof binaries
+proof-with-pis.bin

--- a/circuits/circuit-for-supplier/script/src/main.rs
+++ b/circuits/circuit-for-supplier/script/src/main.rs
@@ -88,6 +88,11 @@ fn main() {
     let mut proof = client.prove(&pk, &stdin).run().unwrap();
     println!("Successfully generated proof!");
 
+    // Save the proof locally. (Test a round trip of proof serialization and deserialization)
+    proof.save("proof-with-pis.bin").expect("saving proof failed");
+    let deserialized_proof = SP1ProofWithPublicValues::load("proof-with-pis.bin").expect("loading proof failed");
+    println!("Successfully save the proof!");
+
     // Verify the proof.
     client.verify(&proof, &vk).expect("failed to verify proof");
     println!("Successfully verified proof!");


### PR DESCRIPTION
## ref - The code to save a Proof-generated locally

- SP1 doc：https://docs.succinct.xyz/docs/sp1/generating-proofs/basics#example-fibonacci
```rust
    // Test a round trip of proof serialization and deserialization.
    proof.save("proof-with-pis.bin").expect("saving proof failed");
    let deserialized_proof =
        SP1ProofWithPublicValues::load("proof-with-pis.bin").expect("loading proof failed");
```